### PR TITLE
csexec-symbiotic: start symbiotic in sane environment

### DIFF
--- a/csexec-symbiotic.sh
+++ b/csexec-symbiotic.sh
@@ -41,7 +41,8 @@ fi
 
 # Run and convert!
 get-bc -S -o "${ARGV[0]}-$$.bc" "${ARGV[0]}" > /dev/null || exit 1
-symbiotic "${SYMBIOTIC[@]}" --argv="'${ARGV[*]:1}'" "${ARGV[0]}-$$.bc" \
+/usr/bin/env -i /usr/bin/bash -lc \
+  "symbiotic \"${SYMBIOTIC[@]}\" --argv=\"'${ARGV[*]:1}'\" \"${ARGV[0]}-$$.bc\"" \
   2> "$LOGDIR/pid-$$.err" | /usr/bin/tee "$LOGDIR/pid-$$.out" | \
   symbiotic2cs > "$LOGDIR/pid-$$.out.conv"
 

--- a/csexec-symbiotic.sh
+++ b/csexec-symbiotic.sh
@@ -47,4 +47,4 @@ fi
   /usr/bin/symbiotic2cs > "$LOGDIR/pid-$$.out.conv"
 
 # Continue
-exec $(/usr/bin/csexec --print-ld-exec-cmd) "${ARGV[@]}"
+exec $(/usr/bin/csexec --print-ld-exec-cmd ${CSEXEC_ARGV0}) "${ARGV[@]}"

--- a/csexec-symbiotic.sh
+++ b/csexec-symbiotic.sh
@@ -41,8 +41,8 @@ fi
 
 # Run and convert!
 /usr/bin/get-bc -S -o "${ARGV[0]}-$$.bc" "${ARGV[0]}" > /dev/null || exit 1
-/usr/bin/env -i /usr/bin/bash -lc \
-  "/usr/bin/symbiotic \"${SYMBIOTIC[@]}\" --argv=\"'${ARGV[*]:1}'\" \"${ARGV[0]}-$$.bc\"" \
+/usr/bin/env -i /usr/bin/bash -lc 'exec "$@"' symbiotic \
+  /usr/bin/symbiotic "${SYMBIOTIC[@]}" --argv="'${ARGV[*]:1}'" "${ARGV[0]}-$$.bc" \
   2> "$LOGDIR/pid-$$.err" | /usr/bin/tee "$LOGDIR/pid-$$.out" | \
   /usr/bin/symbiotic2cs > "$LOGDIR/pid-$$.out.conv"
 

--- a/csexec-symbiotic.sh
+++ b/csexec-symbiotic.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/bash
 
 usage() {
-  cat << EOF
+  /usr/bin/cat << EOF
 USAGE: $0 -s SYMBIOTIC_ARGS ARGV
 1) Build the source with gllvm and CFLAGS internally used by Symbiotic and
    LDFLAGS='-Wl,--dynamic-linker=/usr/bin/csexec-loader'.
@@ -40,11 +40,11 @@ if [ -z "$LOGDIR" ]; then
 fi
 
 # Run and convert!
-get-bc -S -o "${ARGV[0]}-$$.bc" "${ARGV[0]}" > /dev/null || exit 1
+/usr/bin/get-bc -S -o "${ARGV[0]}-$$.bc" "${ARGV[0]}" > /dev/null || exit 1
 /usr/bin/env -i /usr/bin/bash -lc \
-  "symbiotic \"${SYMBIOTIC[@]}\" --argv=\"'${ARGV[*]:1}'\" \"${ARGV[0]}-$$.bc\"" \
+  "/usr/bin/symbiotic \"${SYMBIOTIC[@]}\" --argv=\"'${ARGV[*]:1}'\" \"${ARGV[0]}-$$.bc\"" \
   2> "$LOGDIR/pid-$$.err" | /usr/bin/tee "$LOGDIR/pid-$$.out" | \
-  symbiotic2cs > "$LOGDIR/pid-$$.out.conv"
+  /usr/bin/symbiotic2cs > "$LOGDIR/pid-$$.out.conv"
 
 # Continue
-exec $(csexec --print-ld-exec-cmd) "${ARGV[@]}"
+exec $(/usr/bin/csexec --print-ld-exec-cmd) "${ARGV[@]}"


### PR DESCRIPTION
csexec-symbiotic is transparently invoked from test programs that often
run in specially crafted environment to exercise the tested binaries.
For example, GNU coreutils sets $PATH such that the just built binaries
are preferred over system-provided binaries with the same name.  This
causes havoc in case symbiotic wants to use system-provided binaries
without specifying them with absolute path.  Especially, when symbiotic
by mistake invokes binaries that use csexec-loader as ELF interpreter,
this recursively invokes csexec-symbiotic and symbiotic in a loop and
attacks the machine with a fork bomb.